### PR TITLE
backout MySQL-python from the depended pkg list

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,4 +20,3 @@ six>=1.7.0
 shade
 diskimage-builder
 voluptuous
-MySQL-python


### PR DESCRIPTION
This is to remove MySQL-python from the depended pkg list as we should change nodepool configure file to use pyMySQL instead.